### PR TITLE
Use dotenv for configuration and switch exercise 2 to OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-api-key
+OPENAI_MODEL=gpt-3.5-turbo

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/Prompt_engineering1/app.py
+++ b/Prompt_engineering1/app.py
@@ -1,7 +1,12 @@
 from flask import Flask, request, jsonify, render_template
 import openai
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 app = Flask(__name__)
-openai.api_key = ''
 reviews = []
 @app.route('/')
 def home():
@@ -10,7 +15,7 @@ def home():
 def submit_review():
     review_text = request.json['review']
     response = openai.chat.completions.create(
-        model='gpt-3.5-turbo',
+        model=MODEL,
         messages=[
             {"role": "system",
              "content": "You are a sentiment analysis tool. you only return: 'neutral', 'positive' or 'negative' Classify the sentiment of the following review."},

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dit project bevat drie eenvoudige voorbeelden van toepassingen waarbij prompts w
 ## Mappen
 
 - **Prompt_engineering1** – Een webapplicatie waarin je een review kunt invoeren. Via de OpenAI API wordt de review geclassificeerd als positief, neutraal of negatief. Het resultaat wordt getoond in een gekleurde tekstbalk.
-- **prompt_engineering2** – Vraagt om een beschrijving van een stemming en genereert vervolgens CSS-kleuren die daarbij passen. Deze app gebruikt een lokale LLM via de OpenAI-client.
+- **prompt_engineering2** – Vraagt om een beschrijving van een stemming en genereert vervolgens CSS-kleuren die daarbij passen. Deze app maakt nu gebruik van de OpenAI API.
 - **prompt_engineering3** – Toont hoe je met natuurlijke taal SQL-query's kunt genereren. De gegenereerde query wordt uitgevoerd op een SQLite-database.
 
 ## Installatie
@@ -14,7 +14,9 @@ Dit project bevat drie eenvoudige voorbeelden van toepassingen waarbij prompts w
    ```bash
    pip install -r requirements.txt
    ```
-2. (Optioneel) Voor project 3 kun je eerst de database aanmaken met:
+2. Maak een `.env`-bestand aan met daarin minstens de variabelen `OPENAI_API_KEY` en `OPENAI_MODEL`.
+   Deze worden door alle oefeningen gebruikt om het juiste model te kiezen en de API-sleutel te laden.
+3. (Optioneel) Voor project 3 kun je eerst de database aanmaken met:
    ```bash
    python prompt_engineering3/create_db.py
    ```

--- a/prompt_engineering2/app.py
+++ b/prompt_engineering2/app.py
@@ -1,8 +1,12 @@
 from flask import Flask, request, jsonify, render_template
-from openai import OpenAI
+import openai
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 app = Flask(__name__)
-# Initialize OpenAI client
-client = OpenAI(base_url="http://localhost:1234/v1", api_key="lm-studio")
 
 @app.route('/')
 def home():
@@ -10,8 +14,8 @@ def home():
 @app.route('/get_css_colors', methods=['POST'])
 def get_css_colors():
     mood = request.json['mood']
-    response = client.chat.completions.create(
-        model="lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF",
+    response = openai.chat.completions.create(
+        model=MODEL,
         messages=[
             {
                 "role": "system",

--- a/prompt_engineering3/app.py
+++ b/prompt_engineering3/app.py
@@ -1,9 +1,13 @@
 from flask import Flask, request, jsonify, render_template
 import sqlite3
 import openai
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
 app = Flask(__name__)
-# Configure OpenAI API Key  
-openai.api_key = ''
 def execute_query(query):
     connection = sqlite3.connect('chocolate_shop.db')
     cursor = connection.cursor()
@@ -19,7 +23,7 @@ def home():
 def ask():
     user_question = request.json.get('question')
     response = openai.chat.completions.create(
-        model="gpt-4o",
+        model=MODEL,
         messages=[
             {
                 "role": "system",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 openai
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables using `python-dotenv`
- use model and API key from `.env`
- update exercise 2 to call OpenAI API directly
- document the new `.env` file and update requirements
- add sample `.env.example` and `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416df50c4c832fafdf0f4b8e111cc5